### PR TITLE
Feat/qf round close cap

### DIFF
--- a/migration/1728374264199-addQfRoundCloseCap.ts
+++ b/migration/1728374264199-addQfRoundCloseCap.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQfRoundCloseCap1728374264199 implements MigrationInterface {
+  name = 'AddQfRoundCloseCap1728374264199';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qf_round" ADD "roundUSDCloseCapPerProject" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "qf_round" DROP COLUMN "roundUSDCloseCapPerProject"`,
+    );
+  }
+}

--- a/src/entities/earlyAccessRound.ts
+++ b/src/entities/earlyAccessRound.ts
@@ -52,20 +52,23 @@ export class EarlyAccessRound extends BaseEntity {
 
   // Virtual Field to calculate cumulative cap per project
   @Field(() => Float, { nullable: true })
-  cumulativeCapPerProject?: number;
+  cumulativeUSDCapPerProject?: number;
 
   // Virtual Field to calculate cumulative cap per user per project
   @Field(() => Float, { nullable: true })
-  cumulativeCapPerUserPerProject?: number;
+  cumulativeUSDCapPerUserPerProject?: number;
 
   @AfterLoad()
   async calculateCumulativeCaps(): Promise<void> {
-    const { cumulativeCapPerProject, cumulativeCapPerUserPerProject } =
+    const { cumulativeUSDCapPerProject, cumulativeUSDCapPerUserPerProject } =
       await EarlyAccessRound.createQueryBuilder('eaRound')
-        .select('sum(eaRound.roundUSDCapPerProject)', 'cumulativeCapPerProject')
+        .select(
+          'sum(eaRound.roundUSDCapPerProject)',
+          'cumulativeUSDCapPerProject',
+        )
         .addSelect(
           'sum(eaRound.roundUSDCapPerUserPerProject)',
-          'cumulativeCapPerUserPerProject',
+          'cumulativeUSDCapPerUserPerProject',
         )
         .where('eaRound.roundNumber <= :roundNumber', {
           roundNumber: this.roundNumber,
@@ -73,9 +76,11 @@ export class EarlyAccessRound extends BaseEntity {
         .cache('cumulativeCapEarlyAccessRound-' + this.roundNumber, 300000)
         .getRawOne();
 
-    this.cumulativeCapPerProject = parseFloat(cumulativeCapPerProject || 0);
-    this.cumulativeCapPerUserPerProject = parseFloat(
-      cumulativeCapPerUserPerProject || 0,
+    this.cumulativeUSDCapPerProject = parseFloat(
+      cumulativeUSDCapPerProject || 0,
+    );
+    this.cumulativeUSDCapPerUserPerProject = parseFloat(
+      cumulativeUSDCapPerUserPerProject || 0,
     );
   }
 }

--- a/src/entities/qfRound.ts
+++ b/src/entities/qfRound.ts
@@ -13,7 +13,6 @@ import {
 } from 'typeorm';
 import { Project } from './project';
 import { Donation } from './donation';
-import { EarlyAccessRound } from './earlyAccessRound';
 
 @Entity()
 @ObjectType()
@@ -130,6 +129,10 @@ export class QfRound extends BaseEntity {
 
   @Field(() => Int, { nullable: true })
   @Column({ nullable: true })
+  roundUSDCloseCapPerProject?: number;
+
+  @Field(() => Int, { nullable: true })
+  @Column({ nullable: true })
   roundUSDCapPerUserPerProject?: number;
 
   // Virtual fields for cumulative caps
@@ -148,20 +151,9 @@ export class QfRound extends BaseEntity {
   }
 
   @AfterLoad()
-  async calculateCumulativeCaps(): Promise<void> {
+  async calculateCumulativeCaps() {
     if (this.roundNumber === 1) {
-      const { cumulativeUSDCapPerProject } =
-        await EarlyAccessRound.createQueryBuilder('eaRound')
-          .select(
-            'sum(eaRound.roundUSDCapPerProject)',
-            'cumulativeUSDCapPerProject',
-          )
-          .cache('cumulativeCapQfRound1', 3000)
-          .getRawOne();
-      this.cumulativeUSDCapPerProject =
-        parseFloat(cumulativeUSDCapPerProject || 0) +
-        (this.roundUSDCapPerProject || 0);
-
+      this.cumulativeUSDCapPerProject = this.roundUSDCapPerProject || 0;
       this.cumulativeUSDCapPerUserPerProject =
         this.roundUSDCapPerUserPerProject || 0;
     } else {

--- a/src/entities/qfRound.ts
+++ b/src/entities/qfRound.ts
@@ -134,10 +134,10 @@ export class QfRound extends BaseEntity {
 
   // Virtual fields for cumulative caps
   @Field(() => Float, { nullable: true })
-  cumulativeCapPerProject?: number;
+  cumulativeUSDCapPerProject?: number;
 
   @Field(() => Float, { nullable: true })
-  cumulativeCapPerUserPerProject?: number;
+  cumulativeUSDCapPerUserPerProject?: number;
 
   // only projects with status active can be listed automatically
   isEligibleNetwork(donationNetworkId: number): boolean {
@@ -150,23 +150,23 @@ export class QfRound extends BaseEntity {
   @AfterLoad()
   async calculateCumulativeCaps(): Promise<void> {
     if (this.roundNumber === 1) {
-      const { cumulativeCapPerProject } =
+      const { cumulativeUSDCapPerProject } =
         await EarlyAccessRound.createQueryBuilder('eaRound')
           .select(
             'sum(eaRound.roundUSDCapPerProject)',
-            'cumulativeCapPerProject',
+            'cumulativeUSDCapPerProject',
           )
           .cache('cumulativeCapQfRound1', 3000)
           .getRawOne();
-      this.cumulativeCapPerProject =
-        parseFloat(cumulativeCapPerProject || 0) +
+      this.cumulativeUSDCapPerProject =
+        parseFloat(cumulativeUSDCapPerProject || 0) +
         (this.roundUSDCapPerProject || 0);
 
-      this.cumulativeCapPerUserPerProject =
+      this.cumulativeUSDCapPerUserPerProject =
         this.roundUSDCapPerUserPerProject || 0;
     } else {
-      this.cumulativeCapPerProject = 0;
-      this.cumulativeCapPerUserPerProject = 0;
+      this.cumulativeUSDCapPerProject = 0;
+      this.cumulativeUSDCapPerUserPerProject = 0;
     }
   }
 }

--- a/src/orm.ts
+++ b/src/orm.ts
@@ -46,6 +46,7 @@ export class AppDataSource {
         dropSchema,
         logger: 'advanced-console',
         logging: ['error'],
+        ssl: config.get('TYPEORM_DISABLE_SSL') === 'true' ? false : undefined, // use default in case it's not set
         cache: isTestEnv
           ? false
           : {

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -28,6 +28,7 @@ const ormConfig: DataSourceOptions = {
   username: process.env.TYPEORM_DATABASE_USER,
   password: process.env.TYPEORM_DATABASE_PASSWORD,
   database: process.env.TYPEORM_DATABASE_NAME,
+  ssl: process.env.TYPEORM_DISABLE_SSL === 'true' ? false : undefined, // use default in case it's not set
   entities: getEntities(),
   migrations: ['migration/*.ts'],
   synchronize: process.env.NODE_ENV !== 'production', // Enable sync for test environments

--- a/src/repositories/earlyAccessRoundRepository.test.ts
+++ b/src/repositories/earlyAccessRoundRepository.test.ts
@@ -232,8 +232,10 @@ describe('EarlyAccessRound Cumulative Cap Test Cases', () => {
       where: { id: savedRound.id },
     });
 
-    expect(updatedEarlyAccessRound?.cumulativeCapPerProject).to.equal(1000000);
-    expect(updatedEarlyAccessRound?.cumulativeCapPerUserPerProject).to.equal(
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerProject).to.equal(
+      1000000,
+    );
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerUserPerProject).to.equal(
       50000,
     );
   });
@@ -267,8 +269,10 @@ describe('EarlyAccessRound Cumulative Cap Test Cases', () => {
     });
 
     // The cumulative cap should be the sum of caps from all previous rounds
-    expect(updatedEarlyAccessRound?.cumulativeCapPerProject).to.equal(4500000); // 1000000 + 2000000 + 1500000
-    expect(updatedEarlyAccessRound?.cumulativeCapPerUserPerProject).to.equal(
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerProject).to.equal(
+      4500000,
+    ); // 1000000 + 2000000 + 1500000
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerUserPerProject).to.equal(
       225000,
     ); // 50000 + 100000 + 75000
   });
@@ -301,8 +305,10 @@ describe('EarlyAccessRound Cumulative Cap Test Cases', () => {
     });
 
     // The cumulative cap should skip round 2 and only sum rounds 1 and 3
-    expect(updatedEarlyAccessRound?.cumulativeCapPerProject).to.equal(2500000); // 1000000 + 1500000
-    expect(updatedEarlyAccessRound?.cumulativeCapPerUserPerProject).to.equal(
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerProject).to.equal(
+      2500000,
+    ); // 1000000 + 1500000
+    expect(updatedEarlyAccessRound?.cumulativeUSDCapPerUserPerProject).to.equal(
       125000,
     ); // 50000 + 75000
   });

--- a/src/repositories/qfRoundRepository.test.ts
+++ b/src/repositories/qfRoundRepository.test.ts
@@ -648,8 +648,8 @@ function findQfRoundCumulativeCapsTestCases() {
 
     const roundFromDB = await findQfRoundById(savedRound.id);
 
-    expect(roundFromDB?.cumulativeCapPerProject).to.equal(1000000);
-    expect(roundFromDB?.cumulativeCapPerUserPerProject).to.equal(50000);
+    expect(roundFromDB?.cumulativeUSDCapPerProject).to.equal(1000000);
+    expect(roundFromDB?.cumulativeUSDCapPerUserPerProject).to.equal(50000);
   });
 
   it('should calculate cumulative cap across multiple rounds', async () => {
@@ -694,8 +694,8 @@ function findQfRoundCumulativeCapsTestCases() {
 
     // The cumulative cap should be the sum of caps from all previous rounds
     // Only first round matters
-    expect(roundFromDB?.cumulativeCapPerProject).to.equal(0);
-    expect(roundFromDB?.cumulativeCapPerUserPerProject).to.equal(0);
+    expect(roundFromDB?.cumulativeUSDCapPerProject).to.equal(0);
+    expect(roundFromDB?.cumulativeUSDCapPerUserPerProject).to.equal(0);
   });
 
   it('should only return cumulutive capsfor the first round', async () => {
@@ -738,7 +738,7 @@ function findQfRoundCumulativeCapsTestCases() {
     const roundFromDB = await findQfRoundById(firstRound.id);
 
     // The cumulative cap should skip round 2 and only sum rounds 1 and 3
-    expect(roundFromDB?.cumulativeCapPerProject).to.equal(1000000); // 1000000 + 1500000
-    expect(roundFromDB?.cumulativeCapPerUserPerProject).to.equal(50000); // 50000 + 75000
+    expect(roundFromDB?.cumulativeUSDCapPerProject).to.equal(1000000); // 1000000 + 1500000
+    expect(roundFromDB?.cumulativeUSDCapPerUserPerProject).to.equal(50000); // 50000 + 75000
   });
 }

--- a/src/resolvers/roundsResolver.test.ts
+++ b/src/resolvers/roundsResolver.test.ts
@@ -157,8 +157,11 @@ function fetchAllRoundsTestCases() {
     ); // 50000 + 100000
 
     // For QfRound1
-    assert.equal(_qf1.cumulativeUSDCapPerProject, 3_500_000); // 1,000,000 + 2,000,000 + 500,000
-    assert.equal(_qf1.cumulativeUSDCapPerUserPerProject, 25000); // 50000 + 100000 + 25000
+    assert.equal(_qf1.cumulativeUSDCapPerProject, _qf1.roundUSDCapPerProject);
+    assert.equal(
+      _qf1.cumulativeUSDCapPerUserPerProject,
+      _qf1.roundUSDCapPerUserPerProject,
+    );
 
     // For QfRound2
     assert.equal(_qf2.cumulativeUSDCapPerProject, 0); // No additional cap

--- a/src/resolvers/roundsResolver.test.ts
+++ b/src/resolvers/roundsResolver.test.ts
@@ -140,23 +140,29 @@ function fetchAllRoundsTestCases() {
     // Cumulative caps should sum up up to each round
 
     // Example assertions (adjust based on actual roundNumber assignments)
-    // Here, cumulativeCapPerProject and cumulativeCapPerUserPerProject are summed across all EarlyAccessRounds and QfRounds
+    // Here, cumulativeUSDCapPerProject and cumulativeUSDCapPerUserPerProject are summed across all EarlyAccessRounds and QfRounds
 
     // For EarlyAccessRound1
-    assert.equal(earlyAccessRounds[0].cumulativeCapPerProject, 1_000_000);
-    assert.equal(earlyAccessRounds[0].cumulativeCapPerUserPerProject, 50_000);
+    assert.equal(earlyAccessRounds[0].cumulativeUSDCapPerProject, 1_000_000);
+    assert.equal(
+      earlyAccessRounds[0].cumulativeUSDCapPerUserPerProject,
+      50_000,
+    );
 
     // For EarlyAccessRound2
-    assert.equal(earlyAccessRounds[1].cumulativeCapPerProject, 3_000_000); // 1000000 + 2000000
-    assert.equal(earlyAccessRounds[1].cumulativeCapPerUserPerProject, 150_000); // 50000 + 100000
+    assert.equal(earlyAccessRounds[1].cumulativeUSDCapPerProject, 3_000_000); // 1000000 + 2000000
+    assert.equal(
+      earlyAccessRounds[1].cumulativeUSDCapPerUserPerProject,
+      150_000,
+    ); // 50000 + 100000
 
     // For QfRound1
-    assert.equal(_qf1.cumulativeCapPerProject, 3_500_000); // 1,000,000 + 2,000,000 + 500,000
-    assert.equal(_qf1.cumulativeCapPerUserPerProject, 25000); // 50000 + 100000 + 25000
+    assert.equal(_qf1.cumulativeUSDCapPerProject, 3_500_000); // 1,000,000 + 2,000,000 + 500,000
+    assert.equal(_qf1.cumulativeUSDCapPerUserPerProject, 25000); // 50000 + 100000 + 25000
 
     // For QfRound2
-    assert.equal(_qf2.cumulativeCapPerProject, 0); // No additional cap
-    assert.equal(_qf2.cumulativeCapPerUserPerProject, 0); // No additional cap
+    assert.equal(_qf2.cumulativeUSDCapPerProject, 0); // No additional cap
+    assert.equal(_qf2.cumulativeUSDCapPerUserPerProject, 0); // No additional cap
   });
 }
 
@@ -235,8 +241,8 @@ function fetchActiveRoundTestCases() {
     assert.equal(response.activeRound.roundUSDCapPerProject, 500000);
     assert.equal(response.activeRound.roundUSDCapPerUserPerProject, 25000);
     assert.equal(response.activeRound.tokenPrice, 0.12345678);
-    assert.equal(response.activeRound.cumulativeCapPerProject, 500000);
-    assert.equal(response.activeRound.cumulativeCapPerUserPerProject, 25000);
+    assert.equal(response.activeRound.cumulativeUSDCapPerProject, 500000);
+    assert.equal(response.activeRound.cumulativeUSDCapPerUserPerProject, 25000);
   });
 
   it('should return the currently active QF round and no active Early Access round', async () => {
@@ -275,8 +281,8 @@ function fetchActiveRoundTestCases() {
     assert.equal(response.activeRound.roundUSDCapPerProject, 500000);
     assert.equal(response.activeRound.roundUSDCapPerUserPerProject, 25000);
     assert.equal(response.activeRound.tokenPrice, 0.12345678);
-    assert.equal(response.activeRound.cumulativeCapPerProject, 500000);
-    assert.equal(response.activeRound.cumulativeCapPerUserPerProject, 25000);
+    assert.equal(response.activeRound.cumulativeUSDCapPerProject, 500000);
+    assert.equal(response.activeRound.cumulativeUSDCapPerUserPerProject, 25000);
   });
 
   it('should not return any round when qf round isActive is true but beginDate is in the future', async () => {

--- a/src/services/qAccService.test.ts
+++ b/src/services/qAccService.test.ts
@@ -177,7 +177,7 @@ describe('qAccService', () => {
     })) as EarlyAccessRound;
     assert.equal(
       result,
-      lastRound!.cumulativeCapPerUserPerProject! / lastRound!.tokenPrice! -
+      lastRound!.cumulativeUSDCapPerUserPerProject! / lastRound!.tokenPrice! -
         donationSum,
     );
   });
@@ -189,7 +189,8 @@ describe('qAccService', () => {
     await insertDonation({
       earlyAccessRoundId: lastRound.id,
       amount:
-        lastRound.cumulativeCapPerUserPerProject! / lastRound.tokenPrice! - 100,
+        lastRound.cumulativeUSDCapPerUserPerProject! / lastRound.tokenPrice! -
+        100,
     });
 
     const result = await qAccService.getQAccDonationCap({
@@ -424,7 +425,7 @@ describe('qAccService', () => {
 
     const qf = await findQfRoundById(qfRound1.id);
 
-    assert.equal(qf?.cumulativeCapPerProject, totalUsdCap);
+    assert.equal(qf?.cumulativeUSDCapPerProject, totalUsdCap);
 
     await updateOrCreateProjectRoundRecord(project.id, qfRound1.id);
     const qfProjectRoundRecord = await getProjectRoundRecord(

--- a/src/services/qAccService.test.ts
+++ b/src/services/qAccService.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import moment from 'moment';
 import { IsNull, Not } from 'typeorm';
-import _ from 'lodash';
 import {
   createDonationData,
   createProjectData,
@@ -103,6 +102,7 @@ describe('qAccService', () => {
       beginDate: moment().subtract(1, 'days').toDate(),
       endDate: moment().add(1, 'days').toDate(),
       roundUSDCapPerProject: 10_000,
+      roundUSDCloseCapPerProject: 10_500,
       roundUSDCapPerUserPerProject: 2_500,
       tokenPrice: 0.5,
     }).save();
@@ -227,7 +227,7 @@ describe('qAccService', () => {
 
     assert.equal(
       result,
-      (qfRound1.roundUSDCapPerUserPerProject! / qfRound1.tokenPrice!) * 2,
+      qfRound1.roundUSDCapPerUserPerProject! / qfRound1.tokenPrice!,
     );
   });
 
@@ -250,14 +250,10 @@ describe('qAccService', () => {
   });
 
   it('should allow 250$ donation if qf round cap is filled for new donors', async () => {
-    const amountUsd = _.sum(
-      [...earlyAccessRounds, qfRound1].map(
-        round => round.roundUSDCapPerProject!,
-      ),
-    );
+    await qfRound1.reload();
     await insertDonation({
       qfRoundId: qfRound1.id,
-      amount: amountUsd / qfRound1.tokenPrice!,
+      amount: qfRound1.roundUSDCapPerProject! / qfRound1.tokenPrice!,
     });
 
     const newUser = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
@@ -272,12 +268,8 @@ describe('qAccService', () => {
   });
 
   it('should return correct value for users has donated close to cap if qf round', async () => {
-    const amountUsd =
-      _.sum(
-        [...earlyAccessRounds, qfRound1].map(
-          round => round.roundUSDCapPerProject!,
-        ),
-      ) - 150;
+    const amountUsd = qfRound1.roundUSDCapPerProject!;
+
     await insertDonation({
       qfRoundId: qfRound1.id,
       amount: amountUsd / qfRound1.tokenPrice!,
@@ -319,11 +311,7 @@ describe('qAccService', () => {
       generateRandomEtheriumAddress(),
     );
 
-    const totalUsdCap = _.sum(
-      [...earlyAccessRounds, qfRound1].map(
-        round => round.roundUSDCapPerProject!,
-      ),
-    );
+    const totalUsdCap = qfRound1.roundUSDCapPerProject!;
 
     await insertDonation(
       {
@@ -399,11 +387,7 @@ describe('qAccService', () => {
 
     const qfDonor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
 
-    const totalUsdCap = _.sum(
-      [...earlyAccessRounds, qfRound1].map(
-        round => round.roundUSDCapPerProject!,
-      ),
-    );
+    const totalUsdCap = qfRound1.roundUSDCapPerProject!;
 
     const qfRoundCap = totalUsdCap / qfRound1.tokenPrice!;
 
@@ -447,5 +431,52 @@ describe('qAccService', () => {
     });
 
     assert.equal(250 / qfRound1.tokenPrice!, userCap);
+  });
+
+  it('should return 0 after qf round close cap is reached', async () => {
+    const eaDonor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const qfDonor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const totalUsdCap = qfRound1.roundUSDCloseCapPerProject!;
+
+    await insertDonation(
+      {
+        earlyAccessRoundId: earlyAccessRounds[0].id,
+        amount: totalUsdCap / qfRound1.tokenPrice!,
+      },
+      eaDonor.id,
+    );
+
+    const result = await qAccService.getQAccDonationCap({
+      projectId: project.id,
+      userId: qfDonor.id,
+      donateTime: qfRound1.beginDate,
+    });
+
+    assert.equal(0, result);
+  });
+
+  it('should return remaining to close cap if the project has passed qf cap', async () => {
+    const eaDonor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+    const qfDonor = await saveUserDirectlyToDb(generateRandomEtheriumAddress());
+
+    const totalUsdCap = qfRound1.roundUSDCloseCapPerProject!;
+    const remainingCap = 30;
+
+    await insertDonation(
+      {
+        earlyAccessRoundId: earlyAccessRounds[0].id,
+        amount: totalUsdCap / qfRound1.tokenPrice! - remainingCap,
+      },
+      eaDonor.id,
+    );
+
+    const result = await qAccService.getQAccDonationCap({
+      projectId: project.id,
+      userId: qfDonor.id,
+      donateTime: qfRound1.beginDate,
+    });
+
+    assert.equal(remainingCap, result);
   });
 });

--- a/src/services/qAccService.ts
+++ b/src/services/qAccService.ts
@@ -123,9 +123,10 @@ const getQAccDonationCap = async ({
     return 0;
   }
 
-  const cumulativeUSDCapPerProject = activeRound.cumulativeCapPerProject || 0;
+  const cumulativeUSDCapPerProject =
+    activeRound.cumulativeUSDCapPerProject || 0;
   const cumulativeUSDCapPerUserPerProject =
-    activeRound.cumulativeCapPerUserPerProject || 0;
+    activeRound.cumulativeUSDCapPerUserPerProject || 0;
   const tokenPrice = activeRound.tokenPrice || Number.MAX_SAFE_INTEGER;
 
   const projectPolRoundCap = cumulativeUSDCapPerProject / tokenPrice;

--- a/test/graphqlQueries.ts
+++ b/test/graphqlQueries.ts
@@ -2054,8 +2054,8 @@ export const fetchAllRoundsQuery = `
         roundUSDCapPerProject
         roundUSDCapPerUserPerProject
         tokenPrice
-        cumulativeCapPerProject
-        cumulativeCapPerUserPerProject
+        cumulativeUSDCapPerProject
+        cumulativeUSDCapPerUserPerProject
       }
       ... on QfRound {
         name
@@ -2066,8 +2066,8 @@ export const fetchAllRoundsQuery = `
         roundUSDCapPerProject
         roundUSDCapPerUserPerProject
         tokenPrice
-        cumulativeCapPerProject
-        cumulativeCapPerUserPerProject
+        cumulativeUSDCapPerProject
+        cumulativeUSDCapPerUserPerProject
       }
     }
   }
@@ -2086,8 +2086,8 @@ export const fetchActiveRoundQuery = `
           roundUSDCapPerProject
           roundUSDCapPerUserPerProject
           tokenPrice
-          cumulativeCapPerProject
-          cumulativeCapPerUserPerProject
+          cumulativeUSDCapPerProject
+          cumulativeUSDCapPerUserPerProject
         }
         ... on QfRound {
           name
@@ -2098,8 +2098,8 @@ export const fetchActiveRoundQuery = `
           roundUSDCapPerProject
           roundUSDCapPerUserPerProject
           tokenPrice
-          cumulativeCapPerProject
-          cumulativeCapPerUserPerProject
+          cumulativeUSDCapPerProject
+          cumulativeUSDCapPerUserPerProject
         }
       }
     }


### PR DESCRIPTION
- Renamed cumulativeCapPerProject to cumulativeUSDCapPerProject
- Renamed cumulativeCapPerUserPerProject to cumulativeUSDCapPerUserPerProject
- After this, the QfRound cap must be saved as the final cap in DB (etc. 1M$ and 1,050,000$) and not as a gap to sum of all EA rounds