### PR TITLE
remove containers for job2 and job3, rename job1 to job

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -180,9 +180,9 @@ jobs:
             ## Update each backend service one by one
             ## First Deployment
             docker compose down qacc-be-graph-ql1
-            docker compose down qacc-be-job1
+            docker compose down qacc-be-job
             docker compose up --force-recreate -d qacc-be-graph-ql1
-            docker compose up --force-recreate -d qacc-be-job1
+            docker compose up --force-recreate -d qacc-be-job
 
             # Wait for qacc-be-graph-ql1 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql1 to become healthy..."
@@ -196,9 +196,9 @@ jobs:
                 echo "qacc-be-graph-ql1 is not healthy, stopping deployment"
                 exit 1
             fi
-            # Check if qacc-be-job1 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job1)" != "\"running\"" ]; then
-                echo "qacc-be-job1 is not running, stopping deployment"
+            # Check if qacc-be-job is running
+            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job)" != "\"running\"" ]; then
+                echo "qacc-be-job is not running, stopping deployment"
                 exit 1
             fi
             echo "First deployment phase completed successfully"
@@ -218,9 +218,7 @@ jobs:
             cd QAcc-BE
             ## Second Deployment
             docker compose down qacc-be-graph-ql2
-            docker compose down qacc-be-job2
             docker compose up --force-recreate -d qacc-be-graph-ql2
-            docker compose up --force-recreate -d qacc-be-job2
 
             # Wait for qacc-be-graph-ql2 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql2 to become healthy..."
@@ -232,11 +230,6 @@ jobs:
             # Check if qacc-be-graph-ql2 is healthy
             if [ "$(docker inspect --format='{{json .State.Health.Status}}' qacc-be-graph-ql2)" != "\"healthy\"" ]; then
                 echo "qacc-be-graph-ql2 is not healthy, stopping deployment"
-                exit 1
-            fi
-            # Check if qacc-be-job2 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job2)" != "\"running\"" ]; then
-                echo "qacc-be-job2 is not running, stopping deployment"
                 exit 1
             fi
             echo "Second deployment phase completed successfully"
@@ -256,9 +249,7 @@ jobs:
             cd QAcc-BE
             ## Third Deployment
             docker compose down qacc-be-graph-ql3
-            docker compose down qacc-be-job3
             docker compose up --force-recreate -d qacc-be-graph-ql3
-            docker compose up --force-recreate -d qacc-be-job3
 
             # Wait for qacc-be-graph-ql3 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql3 to become healthy..."
@@ -270,11 +261,6 @@ jobs:
             # Check if qacc-be-graph-ql3 is healthy
             if [ "$(docker inspect --format='{{json .State.Health.Status}}' qacc-be-graph-ql3)" != "\"healthy\"" ]; then
                 echo "qacc-be-graph-ql3 is not healthy, stopping deployment"
-                exit 1
-            fi
-            # Check if qacc-be-job3 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job3)" != "\"running\"" ]; then
-                echo "qacc-be-job3 is not running, stopping deployment"
                 exit 1
             fi
             echo "First deployment phase completed successfully"

--- a/.github/workflows/staging-pipeline.yml
+++ b/.github/workflows/staging-pipeline.yml
@@ -180,9 +180,9 @@ jobs:
             ## Update each backend service one by one
             ## First Deployment
             docker compose down qacc-be-graph-ql1
-            docker compose down qacc-be-job1
+            docker compose down qacc-be-job
             docker compose up --force-recreate -d qacc-be-graph-ql1
-            docker compose up --force-recreate -d qacc-be-job1
+            docker compose up --force-recreate -d qacc-be-job
 
             # Wait for qacc-be-graph-ql1 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql1 to become healthy..."
@@ -196,9 +196,9 @@ jobs:
                 echo "qacc-be-graph-ql1 is not healthy, stopping deployment"
                 exit 1
             fi
-            # Check if qacc-be-job1 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job1)" != "\"running\"" ]; then
-                echo "qacc-be-job1 is not running, stopping deployment"
+            # Check if qacc-be-job is running
+            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job)" != "\"running\"" ]; then
+                echo "qacc-be-job is not running, stopping deployment"
                 exit 1
             fi
             echo "First deployment phase completed successfully"
@@ -218,9 +218,7 @@ jobs:
             cd QAcc-BE
             ## Second Deployment
             docker compose down qacc-be-graph-ql2
-            docker compose down qacc-be-job2
             docker compose up --force-recreate -d qacc-be-graph-ql2
-            docker compose up --force-recreate -d qacc-be-job2
 
             # Wait for qacc-be-graph-ql2 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql2 to become healthy..."
@@ -232,11 +230,6 @@ jobs:
             # Check if qacc-be-graph-ql2 is healthy
             if [ "$(docker inspect --format='{{json .State.Health.Status}}' qacc-be-graph-ql2)" != "\"healthy\"" ]; then
                 echo "qacc-be-graph-ql2 is not healthy, stopping deployment"
-                exit 1
-            fi
-            # Check if qacc-be-job2 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job2)" != "\"running\"" ]; then
-                echo "qacc-be-job2 is not running, stopping deployment"
                 exit 1
             fi
             echo "Second deployment phase completed successfully"
@@ -256,9 +249,7 @@ jobs:
             cd QAcc-BE
             ## Third Deployment
             docker compose down qacc-be-graph-ql3
-            docker compose down qacc-be-job3
             docker compose up --force-recreate -d qacc-be-graph-ql3
-            docker compose up --force-recreate -d qacc-be-job3
 
             # Wait for qacc-be-graph-ql3 to be healthy (timeout after 5 minutes)
             echo "Waiting for qacc-be-graph-ql3 to become healthy..."
@@ -270,11 +261,6 @@ jobs:
             # Check if qacc-be-graph-ql3 is healthy
             if [ "$(docker inspect --format='{{json .State.Health.Status}}' qacc-be-graph-ql3)" != "\"healthy\"" ]; then
                 echo "qacc-be-graph-ql3 is not healthy, stopping deployment"
-                exit 1
-            fi
-            # Check if qacc-be-job3 is running
-            if [ "$(docker inspect --format='{{json .State.Status}}' qacc-be-job3)" != "\"running\"" ]; then
-                echo "qacc-be-job3 is not running, stopping deployment"
                 exit 1
             fi
             echo "First deployment phase completed successfully"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,40 +77,8 @@ services:
     ports:
       - '4003:4000'
 
-  qacc-be-job1:
+  qacc-be-job:
     container_name: qacc-be-job1
-    image: ${DOCKER_IMAGE}
-    command: npm run start:docker:server
-    environment:
-      - ENVIRONMENT=production
-      - LOG_PATH=/usr/src/app/logs/qacc.log
-      - JOB_MODE=true
-    restart: always
-    volumes:
-      - ./config:/usr/src/app/config
-      - ./config:/usr/src/app/build/config
-      - ./logs-job:/usr/src/app/logs
-    networks:
-      - qacc
-
-  qacc-be-job2:
-    container_name: qacc-be-job2
-    image: ${DOCKER_IMAGE}
-    command: npm run start:docker:server
-    environment:
-      - ENVIRONMENT=production
-      - LOG_PATH=/usr/src/app/logs/qacc.log
-      - JOB_MODE=true
-    restart: always
-    volumes:
-      - ./config:/usr/src/app/config
-      - ./config:/usr/src/app/build/config
-      - ./logs-job:/usr/src/app/logs
-    networks:
-      - qacc
-
-  qacc-be-job3:
-    container_name: qacc-be-job3
     image: ${DOCKER_IMAGE}
     command: npm run start:docker:server
     environment:


### PR DESCRIPTION
this PR contains **only** the pipelines worked on today by @mhmdksh as well as the now **single docker compose file** used for our deployments.

Additionally I removed the redundant job containers, so now we deploy:

- quacc-be-graph-ql-1
- quacc-be-graph-ql-2
- quacc-be-graph-ql-3
- quacc-be-job

Please merge this to staging **and** main - we might need to clean up a little as well. 
