### PR TITLE
Add many-to-many relationship between Projects and Early Access Rounds

### DIFF
--- a/migration/1740501033313-AddProjectEarlyAccessRounds.ts
+++ b/migration/1740501033313-AddProjectEarlyAccessRounds.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProjectEarlyAccessRounds1740501033313
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "project_early_access_rounds_early_access_round" ("projectId" integer NOT NULL, "earlyAccessRoundId" integer NOT NULL, CONSTRAINT "PK_project_early_access_rounds" PRIMARY KEY ("projectId", "earlyAccessRoundId"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_project_early_access_rounds_project" ON "project_early_access_rounds_early_access_round" ("projectId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_project_early_access_rounds_round" ON "project_early_access_rounds_early_access_round" ("earlyAccessRoundId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_early_access_rounds_early_access_round" ADD CONSTRAINT "FK_project_early_access_rounds_project" FOREIGN KEY ("projectId") REFERENCES "project"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_early_access_rounds_early_access_round" ADD CONSTRAINT "FK_project_early_access_rounds_round" FOREIGN KEY ("earlyAccessRoundId") REFERENCES "early_access_round"("id") ON DELETE CASCADE ON UPDATE CASCADE`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "project_early_access_rounds_early_access_round" DROP CONSTRAINT "FK_project_early_access_rounds_round"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_early_access_rounds_early_access_round" DROP CONSTRAINT "FK_project_early_access_rounds_project"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_project_early_access_rounds_round"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_project_early_access_rounds_project"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "project_early_access_rounds_early_access_round"`,
+    );
+  }
+}

--- a/src/entities/earlyAccessRound.ts
+++ b/src/entities/earlyAccessRound.ts
@@ -7,8 +7,10 @@ import {
   UpdateDateColumn,
   Index,
   AfterLoad,
+  ManyToMany,
 } from 'typeorm';
 import { Field, ID, ObjectType, Int, Float } from 'type-graphql';
+import { Project } from './project';
 
 @Entity()
 @ObjectType()
@@ -49,6 +51,10 @@ export class EarlyAccessRound extends BaseEntity {
   @Field(() => Int, { nullable: true })
   @Column({ nullable: true })
   roundPOLCapPerUserPerProject?: number;
+
+  @Field(_type => [Project], { nullable: true })
+  @ManyToMany(_type => Project, project => project.earlyAccessRounds)
+  projects: Project[];
 
   // virtual fields
   @Field(() => Float, { nullable: true })

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -46,6 +46,7 @@ import { EstimatedMatching } from '../types/qfTypes';
 import { Campaign } from './campaign';
 import { ProjectEstimatedMatchingView } from './ProjectEstimatedMatchingView';
 import { ProjectSocialMedia } from './projectSocialMedia';
+import { EarlyAccessRound } from './earlyAccessRound';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const moment = require('moment');
 
@@ -285,6 +286,17 @@ export class Project extends BaseEntity {
   })
   @JoinTable()
   qfRounds: QfRound[];
+
+  @Field(_type => [EarlyAccessRound], { nullable: true })
+  @ManyToMany(
+    _type => EarlyAccessRound,
+    earlyAccessRound => earlyAccessRound.projects,
+    {
+      nullable: true,
+    },
+  )
+  @JoinTable()
+  earlyAccessRounds: EarlyAccessRound[];
 
   @Field(_type => Float, { nullable: true })
   @Column('float', { nullable: true })

--- a/src/services/qAccService.ts
+++ b/src/services/qAccService.ts
@@ -15,6 +15,7 @@ import {
   GITCOIN_PASSPORT_MIN_VALID_SCORER_SCORE,
 } from '../constants/gitcoin';
 import { Donation, DONATION_STATUS } from '../entities/donation';
+import { Project } from '../entities/project';
 
 const getEaProjectRoundRecord = async ({
   projectId,
@@ -116,6 +117,16 @@ const getQAccDonationCap = async ({
 
   if (isEarlyAccess) {
     activeRound = activeEarlyAccessRound;
+    // Check if project is in the active early access round
+    const project = await Project.findOne({
+      where: { id: projectId },
+      relations: ['earlyAccessRounds'],
+    });
+    if (
+      !project?.earlyAccessRounds?.some(round => round.id === activeRound?.id)
+    ) {
+      return 0; // Project is not in this early access round
+    }
   } else {
     activeQfRound = await findActiveQfRound({
       date: donateTime,
@@ -127,6 +138,15 @@ const getQAccDonationCap = async ({
       donateTime <= activeQfRound.endDate
     ) {
       activeRound = activeQfRound;
+      // todo: if we need to having some project in qf round, we need to check this
+      // Check if project is in the active QF round
+      // const project = await Project.findOne({
+      //   where: { id: projectId },
+      //   relations: ['qfRounds'],
+      // });
+      // if (!project?.qfRounds?.some(round => round.id === activeRound?.id)) {
+      //   return 0; // Project is not in this QF round
+      // }
     }
   }
 

--- a/src/services/qAccService.ts
+++ b/src/services/qAccService.ts
@@ -15,7 +15,7 @@ import {
   GITCOIN_PASSPORT_MIN_VALID_SCORER_SCORE,
 } from '../constants/gitcoin';
 import { Donation, DONATION_STATUS } from '../entities/donation';
-import { Project } from '../entities/project';
+// import { Project } from '../entities/project';
 
 const getEaProjectRoundRecord = async ({
   projectId,
@@ -117,16 +117,17 @@ const getQAccDonationCap = async ({
 
   if (isEarlyAccess) {
     activeRound = activeEarlyAccessRound;
+    // todo: if we need to having some project in early access round, we need to check this
     // Check if project is in the active early access round
-    const project = await Project.findOne({
-      where: { id: projectId },
-      relations: ['earlyAccessRounds'],
-    });
-    if (
-      !project?.earlyAccessRounds?.some(round => round.id === activeRound?.id)
-    ) {
-      return 0; // Project is not in this early access round
-    }
+    // const project = await Project.findOne({
+    //   where: { id: projectId },
+    //   relations: ['earlyAccessRounds'],
+    // });
+    // if (
+    //   !project?.earlyAccessRounds?.some(round => round.id === activeRound?.id)
+    // ) {
+    //   return 0; // Project is not in this early access round
+    // }
   } else {
     activeQfRound = await findActiveQfRound({
       date: donateTime,


### PR DESCRIPTION
- Update EarlyAccessRound and Project entities to support bidirectional many-to-many relationship
- Modify QAccService to check project eligibility in early access rounds
- Add GraphQL field mappings for the new relationship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for early access rounds, allowing projects to be uniquely associated with specific funding events.
  - Enhanced data model with many-to-many relationships between projects and early access rounds.
  - Expanded donation cap calculations to include future eligibility checks for projects in active funding rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->