### PR TITLE
Add hasEARound column to Project entity

### DIFF
--- a/migration/1740510537342-AddHasEARoundToProject.ts
+++ b/migration/1740510537342-AddHasEARoundToProject.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddHasEARoundToProject1740510537342 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add hasEARound column with default false
+    await queryRunner.query(
+      `ALTER TABLE "project" ADD COLUMN "hasEARound" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "project" DROP COLUMN "hasEARound"`);
+  }
+}

--- a/src/entities/project.ts
+++ b/src/entities/project.ts
@@ -492,6 +492,10 @@ export class Project extends BaseEntity {
   @Column({ type: 'int', nullable: true })
   matchingFunds?: number;
 
+  @Field(_type => Boolean)
+  @Column({ type: 'boolean', default: false })
+  hasEARound: boolean;
+
   // only projects with status active can be listed automatically
   static pendingReviewSince(maximumDaysForListing: number) {
     const maxDaysForListing = moment()


### PR DESCRIPTION
Add a boolean column to track if a project has an Early Access Round

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new project flag to indicate the presence of an Early Access Round.
  - This update enhances project records for improved tracking and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->