### PR TITLE
Allow null value for squid request id

### DIFF
--- a/migration/1741700000000-make-squid-request-id-nullable.ts
+++ b/migration/1741700000000-make-squid-request-id-nullable.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeSquidRequestIdNullable1741700000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "swap_transaction"
+      ALTER COLUMN "squidRequestId" DROP NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "swap_transaction"
+      ALTER COLUMN "squidRequestId" SET NOT NULL;
+    `);
+  }
+}

--- a/src/entities/swapTransaction.ts
+++ b/src/entities/swapTransaction.ts
@@ -23,9 +23,9 @@ export class SwapTransaction extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Field()
-  @Column()
-  squidRequestId: string;
+  @Field({ nullable: true })
+  @Column({ nullable: true })
+  squidRequestId?: string;
 
   @Field()
   @Column()

--- a/src/repositories/swapRepository.ts
+++ b/src/repositories/swapRepository.ts
@@ -44,7 +44,7 @@ export const createSwap = async (params: {
   fromChainId: string;
   toChainId: string;
   transactionHash: string;
-  requestId: string;
+  requestId?: string;
 }): Promise<SwapTransaction> => {
   const swap = SwapTransaction.create({
     fromTokenAddress: params.fromToken,

--- a/src/resolvers/donationResolver.ts
+++ b/src/resolvers/donationResolver.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Service } from 'typedi';
 import { GraphQLJSON } from 'graphql-scalars';
 import {
@@ -219,8 +220,8 @@ class DonationMetrics {
 
 @InputType()
 class SwapTransactionInput {
-  @Field()
-  squidRequestId: string;
+  @Field({ nullable: true })
+  squidRequestId?: string;
 
   @Field()
   firstTxHash: string;
@@ -888,7 +889,7 @@ export class DonationResolver {
       let donationStatus = DONATION_STATUS.PENDING;
       if (swapData) {
         swapTransaction = await SwapTransaction.create({
-          squidRequestId: swapData.squidRequestId,
+          ...(swapData.squidRequestId && { squidRequestId: swapData.squidRequestId }),
           firstTxHash: swapData.firstTxHash,
           fromChainId: swapData.fromChainId,
           toChainId: swapData.toChainId,

--- a/src/services/cronJobs/syncSwapTransactions.ts
+++ b/src/services/cronJobs/syncSwapTransactions.ts
@@ -120,7 +120,7 @@ const verifySwapTransaction = async (swapId: number) => {
 
     const params = {
       transactionId: swap.firstTxHash,
-      requestId: swap.squidRequestId,
+      ...(swap.squidRequestId && { requestId: swap.squidRequestId }),
       fromChainId: swap.fromChainId.toString(),
       toChainId: swap.toChainId.toString(),
     };
@@ -129,6 +129,7 @@ const verifySwapTransaction = async (swapId: number) => {
       const status = await getStatus(params);
       logger.debug(`Route status for swap ${swapId}:`, {
         status: status.squidTransactionStatus,
+        requestId: swap.squidRequestId || 'not provided',
       });
 
       // Update swap status in database

--- a/src/services/squidService.ts
+++ b/src/services/squidService.ts
@@ -92,7 +92,7 @@ interface SquidStatusResponse {
 
 export const getStatus = async (params: {
   transactionId: string;
-  requestId: string;
+  requestId?: string;
   fromChainId: string;
   toChainId: string;
 }): Promise<SquidStatusResponse> => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Implemented a database update that now allows transactions to be recorded without a mandatory request identifier.

- **Refactor**
  - Adjusted multiple transaction and donation processes to conditionally include the request identifier only when provided.
  - Enhanced logging clarity by explicitly noting when the request identifier is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->